### PR TITLE
feat: ✨ Add initial marketing assistance to pricing plans

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "rizzui": "0.8.7",
         "sonner": "^1.5.0",
         "tailwind-merge": "^2.5.2",
-        "tailwindcss-animate": "^1.0.7",
+        "tailwindcss-animate": "1.0.7",
         "zod": "^3.23.8",
         "zustand": "4.5.2"
       },

--- a/src/app/(mi-tienda-en-linea)/princing/[slug]/page.tsx
+++ b/src/app/(mi-tienda-en-linea)/princing/[slug]/page.tsx
@@ -30,6 +30,7 @@ export default function PlanBySlugPage({ params }: Props) {
         'Mantenimiento de pedidos',
         'Soporte básico',
         'Estadísticas básicas de ventas',
+        'Asistencia de marketing inicial',
         'Acompañamiento personalizado'
       ],
       slug: 'basic'
@@ -45,6 +46,7 @@ export default function PlanBySlugPage({ params }: Props) {
         'Páginas legales y de contacto',
         'Soporte prioritario',
         'Análisis avanzado de ventas',
+        'Asistencia de marketing inicial',
         'Acompañamiento personalizado'
       ],
       slug: 'standard'
@@ -60,6 +62,7 @@ export default function PlanBySlugPage({ params }: Props) {
         'Diseño exclusivo',
         'Dashboard avanzado',
         'Actualizaciones y mantenimiento continuo',
+        'Asistencia de marketing inicial',
         'Acompañamiento personalizado'
       ],
       slug: 'premium'
@@ -100,6 +103,7 @@ export default function PlanBySlugPage({ params }: Props) {
       items: [
         { name: 'Soporte básico', plans: [true, true, true] },
         { name: 'Soporte prioritario', plans: [false, true, true] },
+        { name: 'Asistencia de marketing inicial', plans: [true, true, true] },
         { name: 'Acompañamiento personalizado', plans: [true, true, true] }
       ]
     },

--- a/src/components/landing/PricingSection.tsx
+++ b/src/components/landing/PricingSection.tsx
@@ -15,6 +15,7 @@ const pricingPlans = [
       'Mantenimiento de pedidos',
       'Soporte básico',
       'Estadísticas básicas de ventas',
+      'Asistencia de marketing inicial',
       'Acompañamiento personalizado'],
     slug: 'basic'
   },
@@ -29,6 +30,7 @@ const pricingPlans = [
       'Páginas legales y de contacto',
       'Soporte prioritario',
       'Análisis avanzado de ventas',
+      'Asistencia de marketing inicial',
       'Acompañamiento personalizado'
     ],
     slug: 'standard'
@@ -44,6 +46,7 @@ const pricingPlans = [
       'Diseño exclusivo',
       'Dashboard avanzado',
       'Actualizaciones y mantenimiento continuo',
+      'Asistencia de marketing inicial',
       'Acompañamiento personalizado'
     ],
     slug: 'premium'


### PR DESCRIPTION
Included 'Asistencia de marketing inicial' to the pricing plans in multiple locations, enhancing the offerings for basic, standard, and premium plans.