### PR TITLE
feat :sparkles: add "Only-Cart" template and expand template layout

### DIFF
--- a/src/components/landing/TemplateSection.tsx
+++ b/src/components/landing/TemplateSection.tsx
@@ -4,18 +4,18 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 
 const templates = [
-  // {
-  //   id: '1',
-  //   image: '/imgs/placeholder.jpg',
-  //   title: 'only-cart',
-  //   category: 'Basic',
-  //   description: 'Template simple y efectivo para tiendas pequeñas.',
-  //   plan: 'Basic',
-  //   url: 'https://only-cart.vercel.app/',
-  //   slug: 'only-cart'
-  // },
   {
     id: '2',
+    image: 'https://res.cloudinary.com/cloudinary-api-images/image/upload/v1730740139/mi-tienda-en-linea-shop/only-cart_momzj3.png',
+    title: 'only-cart',
+    category: 'Basic',
+    description: 'Template simple y efectivo para tiendas pequeñas.',
+    plan: 'Basic',
+    url: 'https://only-cart.vercel.app/',
+    slug: 'only-cart'
+  },
+  {
+    id: '1',
     image: 'https://res.cloudinary.com/cloudinary-api-images/image/upload/v1727216675/mi-tienda-en-linea-shop/rf98xdgad3zez6yzztap.png',
     title: 'bazar campechano',
     category: 'MVP',
@@ -58,7 +58,7 @@ export function TemplateSection() {
     <section id="templates" className="bg-white text-gray-800 pb-20 pt-24">
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold mb-12 text-center">Explora Nuestros Templates</h2>
-        <div className="grid md:grid-cols-2 gap-8 max-w-[1200px] mx-auto">
+        <div className="grid md:grid-cols-3 gap-8 max-w-[1200px] mx-auto">
           {
             templates.map((template, index) => (
               <TemplateCard key={index} {...template} />

--- a/src/seed/seed.ts
+++ b/src/seed/seed.ts
@@ -28,28 +28,33 @@ interface SeedData {
 export const initialData: SeedData = {
 
   templates: [
-    // {
-    //   id: '1',
-    //   title: 'Only-Cart',
-    //   description: 'Ideal para tiendas pequeñas que buscan un enfoque simple y efectivo. Con un carrito de compras intuitivo y un catálogo de productos fácil de gestionar, este template es perfecto para iniciar ventas en línea rápidamente.',
-    //   features: [
-    //     'Interfaz minimalista enfocada en la funcionalidad',
-    //     'Carrito de compras con actualización rápida de productos',
-    //     'Gestión de hasta 100 productos con opciones básicas de personalización',
-    //     'Notificaciones de pedidos y ventas en tiempo real',
-    //     'Soporte técnico básico por correo electrónico',
-    //     'Panel simple de gestión de pedidos y productos',
-    //     'Acompañamiento inicial para configuración',
-    //     'Sin registro de clientes, ideal para ventas directas'
-    //   ],
-    //   plan: 'Basic',
-    //   category: 'Basic',
-    //   slidesImages: null,
-    //   videoUrl: null,
-    //   url: null
-    // },
     {
       id: '2',
+      title: 'Only-Cart',
+      description: 'Ideal para tiendas pequeñas que buscan un enfoque simple y efectivo. Con un carrito de compras intuitivo y un catálogo de productos fácil de gestionar, este template es perfecto para iniciar ventas en línea rápidamente.',
+      features: [
+        'Interfaz minimalista enfocada en la funcionalidad',
+        'Carrito de compras con actualización rápida de productos',
+        'Gestión de hasta 100 productos con opciones básicas de personalización',
+        'Notificaciones de pedidos mediante WhatsApp',
+        'Soporte técnico básico por correo electrónico',
+        'Panel simple de gestión de productos',
+        'Acompañamiento inicial para configuración',
+        'Sin registro de clientes, ideal para ventas directas'
+      ],
+      plan: 'Basic',
+      category: 'Basic',
+      slidesImages: [
+        {
+          id: '1',
+          url: 'https://res.cloudinary.com/cloudinary-api-images/image/upload/v1730740139/mi-tienda-en-linea-shop/only-cart_momzj3.png'
+        }
+      ],
+      videoUrl: null,
+      url: 'https://only-cart.vercel.app'
+    },
+    {
+      id: '3',
       title: 'Moda Shop',
       description: 'Un template elegante y sofisticado diseñado para tiendas de moda. Resalta visualmente tus productos y ofrece una experiencia de compra fluida, desde la navegación hasta la pasarela de pago.',
       features: [
@@ -102,7 +107,7 @@ export const initialData: SeedData = {
       url: 'https://moda-shop.vercel.app'
     },
     {
-      id: '3',
+      id: '1',
       title: 'Bazar Campechano',
       description: 'Un template versátil diseñado para tiendas que ofrecen productos variados. Perfecto para bazares y tiendas con categorías extensas, ofreciendo personalización y herramientas avanzadas para gestionar productos de diferentes tipos.',
       features: [


### PR DESCRIPTION
- Added "Only-Cart" template with Cloudinary-hosted image and details.
- Updated `TemplateSection` grid to display 3 templates per row on desktop.
- Expanded seed data for templates with additional image links and descriptions.