### PR TITLE
feat: add marketing plans and improve landing structure

### DIFF
--- a/src/app/(mi-tienda-en-linea)/page.tsx
+++ b/src/app/(mi-tienda-en-linea)/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { HeaderHero } from '@/components'
 import { BenefitSection, ContactForm, FeatureSection, PricingSection, TemplateSection, ValuePropositionSection } from '@/components/landing'
+import { MarketingPricingSection } from '@/components/landing/MarketingPricingSection'
 import { Button } from '@/components/ui/button'
 
 export default function LandingPage() {
@@ -17,8 +18,11 @@ export default function LandingPage() {
         {/* Templates Section */}
         <TemplateSection />
 
-        {/* Pricing */}
+        {/* Ecommerce Pricing Section */}
         <PricingSection />
+
+        {/* Marketing Pricing Section */}
+        <MarketingPricingSection />
 
         {/* Key Benefits */}
         <BenefitSection />

--- a/src/app/(mi-tienda-en-linea)/princing/[slug]/page.tsx
+++ b/src/app/(mi-tienda-en-linea)/princing/[slug]/page.tsx
@@ -19,7 +19,7 @@ export default function PlanBySlugPage({ params }: Props) {
 
   const pricingPlans = [
     {
-      title: 'Plan Básico',
+      title: 'Ecommerce Básico',
       price: '$99',
       features: [
         'Carrito de compras',
@@ -35,7 +35,7 @@ export default function PlanBySlugPage({ params }: Props) {
       slug: 'basic'
     },
     {
-      title: 'Plan Estándar',
+      title: 'Ecommerce Estándar',
       price: '$299',
       features: [
         'Todas las características del plan básico',
@@ -51,7 +51,7 @@ export default function PlanBySlugPage({ params }: Props) {
       slug: 'standard'
     },
     {
-      title: 'Plan Premium',
+      title: 'Ecommerce Premium',
       price: '$499',
       features: [
         'Todas las características estándar',
@@ -65,6 +65,45 @@ export default function PlanBySlugPage({ params }: Props) {
         'Acompañamiento personalizado'
       ],
       slug: 'premium'
+    },
+    {
+      title: 'Marketing Básico',
+      price: '$149',
+      features: [
+        'Administración de redes sociales: 2-3 publicaciones semanales (promoción directa en publicaciones)',
+        'Creación de copys y diseños simples con Canva y herramientas de AI',
+        'Calendario de publicaciones mensual',
+        'Reporte básico de métricas (interacciones, alcance y crecimiento de seguidores) con explicación personalizada',
+        'Asesoría inicial en gestión de proyectos (uso básico de Trello o Notion)',
+        'Soporte y asesoría directa en marketing digital (enfoque en resultados simples y medibles)'
+      ],
+      slug: 'marketing-basic'
+    },
+    {
+      title: 'Marketing Estándar',
+      price: '$349',
+      features: [
+        'Todas las características del Plan Básico Integral',
+        'Gestión de campañas publicitarias en Facebook Ads (usando el Administrador de Anuncios de Facebook, con configuraciones simples para tráfico frío y retargeting)',
+        'Estrategia de contenido personalizada: 3-4 publicaciones semanales con optimización de copys y segmentación básica',
+        'Informe mensual detallado con métricas clave (incluyendo CTR, interacciones y conversiones) explicado en reuniones directas',
+        'Configuración básica de flujos de trabajo en herramientas como Asana, Trello o Notion',
+        'Definición de objetivos claros (más seguidores, interacciones o contacto vía WhatsApp) y seguimiento personalizado'
+      ],
+      slug: 'marketing-standard'
+    },
+    {
+      title: 'Marketing Premium',
+      price: '$599',
+      features: [
+        'Todas las características del Plan Intermedio Integral',
+        'Producción audiovisual: edición de videos e imágenes (utilizando CapCut y Clipchamp) adaptados a tu marca',
+        'Gestión avanzada de campañas publicitarias: asesoría en segmentación, remarketing y pruebas básicas para optimizar resultados, explicado de forma sencilla',
+        'Consultoría y soporte continuo en marketing digital, con reuniones mensuales para revisar resultados y ajustar estrategias',
+        'Optimización de perfiles y actualización constante de imágenes y portadas en redes sociales',
+        'Capacitación personalizada en marketing digital y en el uso de herramientas de gestión de proyectos, con enfoque práctico y directo'
+      ],
+      slug: 'marketing-premium'
     }
   ]
 
@@ -74,6 +113,8 @@ export default function PlanBySlugPage({ params }: Props) {
       title: plan.title
     }
   })
+
+  const planTitles = ['Básico', 'Estándar', 'Premium']
 
   const features = [
     {
@@ -121,6 +162,16 @@ export default function PlanBySlugPage({ params }: Props) {
         { name: 'Diseño exclusivo', plans: [false, false, true] },
         { name: 'Actualizaciones y mantenimiento continuo', plans: [true, true, true] }
       ]
+    },
+    {
+      category: 'Marketing y Estrategia Digital',
+      items: [
+        { name: 'Administración de redes sociales: 2-3 publicaciones semanales', plans: [true, true, true] },
+        { name: 'Creación de copys y diseños simples con Canva', plans: [true, true, true] },
+        { name: 'Gestión de campañas publicitarias en Facebook Ads', plans: [false, true, true] },
+        { name: 'Producción audiovisual: edición de videos e imágenes', plans: [false, false, true] },
+        { name: 'Consultoría continua en marketing digital', plans: [false, false, true] }
+      ]
     }
   ]
 
@@ -155,7 +206,7 @@ export default function PlanBySlugPage({ params }: Props) {
 
       <div className="py-10 text-white">
         {/* Plans */}
-        <div className="grid md:grid-cols-3 gap-6 mb-8 px-1 sm:px-5 max-w-[1300px] mx-auto">
+        <div className="grid md:grid-cols-3 gap-6 mb-8 p-1 sm:p-5 max-w-[1300px] mx-auto">
           {pricingPlans.map((plan, index) => {
             const { title, price, features, slug } = plan
 
@@ -231,8 +282,10 @@ export default function PlanBySlugPage({ params }: Props) {
                         <thead className="bg-gray-800 sticky top-0">
                           <tr>
                             <th className="p-2 text-left w-1/3"></th>
-                            {pricingPlans.map((plan, index) => (
-                              <th key={index} className="p-2 text-center">{plan.title}</th>
+                            {planTitles.map((title, index) => (
+                              <th key={index} className="p-2 text-center">
+                                {title}
+                              </th>
                             ))}
                           </tr>
                         </thead>

--- a/src/components/info/SectionContentTerms.tsx
+++ b/src/components/info/SectionContentTerms.tsx
@@ -88,6 +88,7 @@ export const SectionContentTerms = () => {
                   <section>
                     <h2 className="text-2xl font-bold mb-4 text-white">1. Descripción del Servicio</h2>
                     <p className="text-gray-200">Mi Tienda en Línea ofrece la creación y mantenimiento de tiendas online personalizadas bajo un esquema de membresía. Cada tienda es desplegada en servidores de Vercel y utiliza Cloudinary para el almacenamiento de imágenes. Los usuarios pueden elegir entre diferentes planes de suscripción con características escalables como el número de productos y funcionalidades adicionales. El dominio personalizado es responsabilidad del usuario, aunque Mi Tienda en Línea ofrece asistencia en el proceso de adquisición.</p>
+                    <p className="text-gray-200 mt-1">Ofrecemos un enfoque integral que no solo cubre la parte técnica de la tienda, sino que también incluye estrategias de marketing digital para impulsar las ventas y la visibilidad de tu negocio en línea.</p>
                   </section>
                 )}
                 {activeSection === 'responsabilidad' && (

--- a/src/components/landing/BenefitSection.tsx
+++ b/src/components/landing/BenefitSection.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle, Headphones, Heart, PenToolIcon, Shield, Users } from 'lucide-react'
+import { BarChart, CheckCircle, Globe, Headphones, Heart, MessageCircle, PenToolIcon, Shield, Users } from 'lucide-react'
 
 const benefits = [
   {
@@ -30,6 +30,21 @@ const benefits = [
     icon: <Heart className="h-12 w-12 text-blue-500" />,
     title: 'Confianza y Trato Personalizado',
     description: 'Queremos que sientas confianza en todo el proceso. Ofrecemos un trato humano y cercano para ayudarte a alcanzar tus metas.'
+  },
+  {
+    icon: <Globe className="h-12 w-12 text-blue-500" />,
+    title: 'Alcance Global',
+    description: 'Con estrategias de marketing digital, tu tienda puede llegar a una audiencia más amplia, ampliando significativamente tu base de clientes potenciales.'
+  },
+  {
+    icon: <MessageCircle className="h-12 w-12 text-blue-500" />,
+    title: 'Interacción Directa con Clientes',
+    description: 'Los canales digitales permiten una comunicación directa y personalizada con tus clientes, fomentando relaciones más sólidas y leales.'
+  },
+  {
+    icon: <BarChart className="h-12 w-12 text-blue-500" />,
+    title: 'Análisis y Optimización en Tiempo Real',
+    description: 'Las herramientas de marketing digital proporcionan datos en tiempo real, permitiéndote ajustar y mejorar tus estrategias de manera continua para maximizar resultados.'
   }
 ]
 

--- a/src/components/landing/HeaderHero.tsx
+++ b/src/components/landing/HeaderHero.tsx
@@ -6,8 +6,8 @@ export const HeaderHero = () => {
 
     <section className='flex gap-2 relative sm:bg-[url("/imgs/banner.png")] bg-[url("/imgs/banner2.png")] bg-fixed bg-cover bg-top bg-no-repeat'>
       <div className="container flex flex-col justify-center items-center text-center mx-auto h-screen max-w-[720px] px-1 z-10 animate-fade-up">
-        <h1 className="text-5xl font-bold mb-6 tracking-wider pt-12">Transforma tu negocio con tu propia tienda en línea</h1>
-        <p className="text-xl mb-8">Control total, sin comisiones ocultas, y soporte cercano en cada paso.</p>
+        <h1 className="text-5xl font-bold mb-6 tracking-wider pt-12">Impulsa tu negocio con soluciones a medida</h1>
+        <p className="text-xl mb-8">Ecommerce, Marketing Digital, Gestión de Proyectos.</p>
         <Button asChild size="lg" className="bg-blue-500 hover:bg-blue-600 text-white rounded-full">
           <Link href={'#contact'}>Empieza Hoy</Link>
         </Button>

--- a/src/components/landing/MarketingPricingSection.tsx
+++ b/src/components/landing/MarketingPricingSection.tsx
@@ -1,0 +1,108 @@
+import { CheckCircle } from 'lucide-react'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card'
+
+const pricingPlans = [
+  {
+    title: 'Marketing Básico',
+    price: '$1,499',
+    features: [
+      'Administración de redes sociales: 2-3 publicaciones semanales (promoción directa en publicaciones)',
+      'Creación de copys y diseños simples con Canva y herramientas de AI',
+      'Calendario de publicaciones mensual',
+      'Reporte básico de métricas (interacciones, alcance y crecimiento de seguidores) con explicación personalizada',
+      'Asesoría inicial en gestión de proyectos (uso básico de Trello o Notion)',
+      'Soporte y asesoría directa en marketing digital (enfoque en resultados simples y medibles)'
+    ],
+    slug: 'marketing-basic'
+  },
+  {
+    title: 'Marketing Estándar',
+    price: '$1,999',
+    features: [
+      'Todas las características del Plan Básico Integral',
+      'Gestión de campañas publicitarias en Facebook Ads (usando el Administrador de Anuncios de Facebook, con configuraciones simples para tráfico frío y retargeting)',
+      'Estrategia de contenido personalizada: 3-4 publicaciones semanales con optimización de copys y segmentación básica',
+      'Informe mensual detallado con métricas clave (incluyendo CTR, interacciones y conversiones) explicado en reuniones directas',
+      'Configuración básica de flujos de trabajo en herramientas como Asana, Trello o Notion',
+      'Definición de objetivos claros (más seguidores, interacciones o contacto vía WhatsApp) y seguimiento personalizado'
+    ],
+    slug: 'marketing-standard'
+  },
+  {
+    title: 'Marketing Premium',
+    price: '$2,499',
+    features: [
+      'Todas las características del Plan Intermedio Integral',
+      'Producción audiovisual: edición de videos e imágenes (utilizando CapCut y Clipchamp) adaptados a tu marca',
+      'Gestión avanzada de campañas publicitarias: asesoría en segmentación, remarketing y pruebas básicas para optimizar resultados, explicado de forma sencilla',
+      'Consultoría y soporte continuo en marketing digital, con reuniones mensuales para revisar resultados y ajustar estrategias',
+      'Optimización de perfiles y actualización constante de imágenes y portadas en redes sociales',
+      'Capacitación personalizada en marketing digital y en el uso de herramientas de gestión de proyectos, con enfoque práctico y directo'
+    ],
+    slug: 'marketing-premium'
+  }
+]
+
+interface PricingCardProps {
+  title: string
+  price: string
+  features: string[]
+  slug: string
+}
+
+export function MarketingPricingSection() {
+  return (
+    <section id="marketing" className="bg-gradient-to-b from-gray-700 to-gray-800 pb-20 pt-24">
+      <div className="container mx-auto px-4">
+        <h2 className="text-3xl font-bold mb-12 text-center">Planes de Suscripción Marketing Digital</h2>
+        <div className="grid md:grid-cols-3 gap-8">
+          {
+            pricingPlans.map((plan, index) => (
+              <PricingCard key={index} {...plan} />
+            )
+            )
+          }
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function PricingCard({ title, price, features, slug }: PricingCardProps) {
+  const isPopular = title === 'Plan Premium'
+  return (
+    <Card className={`bg-gradient-to-br ${isPopular ? 'from-blue-600 to-blue-800' : 'from-gray-700 to-gray-900'} text-white overflow-hidden transition-all duration-300 hover:scale-105 shadow-xl`}>
+      <CardHeader className="text-center p-6 relative">
+        {isPopular && (
+          <div className="absolute top-0 right-0 bg-yellow-400 text-gray-900 text-xs font-bold px-3 py-1 rounded-bl-lg">
+            Más Popular
+          </div>
+        )}
+        <h3 className="text-2xl font-bold mb-2">{title}</h3>
+        <div className="flex items-center justify-center">
+          <span className="text-5xl font-extrabold">{price}</span>
+          <span className="text-xl ml-2">/mes</span>
+        </div>
+      </CardHeader>
+      <CardContent className="p-6">
+        <ul className="space-y-3">
+          {features.map((feature, index) => (
+            <li key={index} className="flex items-start space-x-3">
+              <CheckCircle className="h-5 w-5 text-green-400 flex-shrink-0 mt-1" />
+              <span className="text-sm">{feature}</span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+      <CardFooter className="p-6">
+        <Button asChild className={`w-full ${isPopular ? 'bg-yellow-400 hover:bg-yellow-500 text-gray-900' : 'bg-white hover:bg-gray-100 text-gray-900'} font-bold py-3 rounded-full transition-colors duration-300`}>
+          <Link href={`/princing/${slug}`} className='transition-all duration-300 hover:scale-105' >
+            Más
+          </Link>
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/src/components/landing/PricingSection.tsx
+++ b/src/components/landing/PricingSection.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card'
 
 const pricingPlans = [
   {
-    title: 'Plan Básico',
+    title: 'Ecommerce Básico',
     price: '$99',
     features: [
       'Carrito de compras',
@@ -20,7 +20,7 @@ const pricingPlans = [
     slug: 'basic'
   },
   {
-    title: 'Plan Estándar',
+    title: 'Ecomerce Estándar',
     price: '$299',
     features: [
       'Todas las características del plan básico',
@@ -36,7 +36,7 @@ const pricingPlans = [
     slug: 'standard'
   },
   {
-    title: 'Plan Premium',
+    title: 'Ecommerce Premium',
     price: '$499',
     features: [
       'Todas las características estándar',
@@ -64,7 +64,7 @@ export function PricingSection() {
   return (
     <section id="pricing" className="bg-gradient-to-b from-gray-800 to-gray-700 pb-20 pt-24">
       <div className="container mx-auto px-4">
-        <h2 className="text-3xl font-bold mb-12 text-center">Planes de Suscripción</h2>
+        <h2 className="text-3xl font-bold mb-12 text-center">Planes de Suscripción Ecommerce</h2>
         <div className="grid md:grid-cols-3 gap-8">
           {
             pricingPlans.map((plan, index) => (

--- a/src/components/landing/ValuePrepositionSection.tsx
+++ b/src/components/landing/ValuePrepositionSection.tsx
@@ -1,5 +1,6 @@
-import { CreditCard, Headphones, PenTool } from 'lucide-react'
+import { ChartBar, ChartCandlestick, CreditCard, Headphones, PenTool } from 'lucide-react'
 import { type ReactNode } from 'react'
+import { BsGlobeCentralSouthAsia } from 'react-icons/bs'
 import { Card, CardContent } from '@/components/ui/card'
 
 const valueCards = [
@@ -20,6 +21,24 @@ const valueCards = [
     icon: <CreditCard className="h-16 w-16" />,
     description: 'Planes con precios fijos mensuales. Sin comisiones ocultas.',
     color: 'bg-green-600'
+  },
+  {
+    title: 'Visibilidad Efectiva',
+    icon: <BsGlobeCentralSouthAsia className="h-16 w-16" />,
+    description: 'Destaca en tu nicho con campañas digitales focalizadas.',
+    color: 'bg-teal-600'
+  },
+  {
+    title: 'Interacción Directa',
+    icon: <ChartCandlestick className="h-16 w-16" />,
+    description: 'Comunícate directamente con tus clientes de forma personalizada.',
+    color: 'bg-indigo-600'
+  },
+  {
+    title: 'Optimización Continua',
+    icon: <ChartBar className="h-16 w-16" />,
+    description: 'Mejora tus estrategias con análisis en tiempo real.',
+    color: 'bg-cyan-600'
   }
 ]
 

--- a/src/components/ui/sidebar/Sidebar.tsx
+++ b/src/components/ui/sidebar/Sidebar.tsx
@@ -41,16 +41,16 @@ export const Sidebar = () => {
 
         {/* menú */}
         <div className='mt-16'>
-          <Link href='/#features'
-            onClick={() => { closeMenu() }}
-            className='flex items-center mt-7 p-2 hover:bg-black hover:text-white rounded-none transition-all'>
-            <span className='ml-3 text-xl'>Características</span>
-          </Link>
-
           <Link href='/#templates'
             onClick={() => { closeMenu() }}
             className='flex items-center mt-7 p-2 hover:bg-black hover:text-white rounded-none transition-all'>
-            <span className='ml-3 text-xl'>Templates</span>
+            <span className='ml-3 text-xl'>Ecommerce</span>
+          </Link>
+
+          <Link href='/#marketing'
+            onClick={() => { closeMenu() }}
+            className='flex items-center mt-7 p-2 hover:bg-black hover:text-white rounded-none transition-all'>
+            <span className='ml-3 text-xl'>Marketing Digital</span>
           </Link>
 
           <Link href='/#pricing'

--- a/src/components/ui/top-menu/TopMenu.tsx
+++ b/src/components/ui/top-menu/TopMenu.tsx
@@ -47,8 +47,8 @@ export const TopMenu = () => {
             <IoMenu size={30} />
           </Button>
           <ul className="hidden space-x-4 md:flex">
-            <li><Link href="/#features" className="hover:text-blue-400 transition-colors">Características</Link></li>
-            <li><Link href="/#templates" className="hover:text-blue-400 transition-colors">Templates</Link></li>
+            <li><Link href="/#templates" className="hover:text-blue-400 transition-colors">Ecommerce</Link></li>
+            <li><Link href="/#marketing" className="hover:text-blue-400 transition-colors">Marketing Digital</Link></li>
             <li><Link href="/#pricing" className="hover:text-blue-400 transition-colors">Precios</Link></li>
             <li><Link href="/#contact" className="hover:text-blue-400 transition-colors">Contacto</Link></li>
           </ul>


### PR DESCRIPTION
- Added new marketing plans (`Marketing Básico`, `Marketing Estándar`, `Marketing Premium`) to the pricing page.
- Updated landing page:
  - Added `MarketingPricingSection` for marketing plan pricing.
  - Improved `BenefitSection` and `ValuePropositionSection` with new advantages.
  - Adjusted sidebar and top menu labels to better reflect services.
- Enhanced `SectionContentTerms` with additional details about integrated marketing strategies.
- Fixed minor UI adjustments for consistency across sections.